### PR TITLE
Point to services.adroll.com and pass apikey.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ General Info
 
 API version: v1
 
-API base url: https://api.adroll.com/v1/
+API base url: https://services.adroll.com/api/v1/
 
-API documentation: https://app.adroll.com/api/v1/docs
+API documentation: https://developers.adroll.com/docs/
 
 Setup
 =====
@@ -42,6 +42,7 @@ Set your API username, password and organization eid in your environment
 ENV['ADROLL_USERNAME'] = 'Your User Name'
 ENV['ADROLL_PASSWORD'] = 'Your Password'
 ENV['ADROLL_ORGANIZATION'] = 'Your Organization eid'
+ENV['ADROLL_API_KEY'] = 'Your Developer App apikey'
 ```
 
 Method Calls

--- a/lib/adroll.rb
+++ b/lib/adroll.rb
@@ -32,11 +32,11 @@ require 'adroll/httparty_wrapper'
 
 module AdRoll
   def self.api_base_url
-    'https://api.adroll.com/v1'
+    'https://services.adroll.com/api/v1'
   end
 
   def self.uhura_base_url
-    'https://app.adroll.com/uhura/v1'
+    'https://services.adroll.com/uhura/v1'
   end
 
   def self.user_name
@@ -51,14 +51,19 @@ module AdRoll
     ENV['DEBUG'] == 'true'
   end
 
+  def self.api_key
+    @api_key || ENV['ADROLL_API_KEY']
+  end
+
   def self.organization_eid
     @organization_eid || ENV['ADROLL_ORGANIZATION_EID']
   end
 
-  def self.set_account_data(user_name, password, organization_eid)
+  def self.set_account_data(user_name, password, organization_eid, api_key)
     @user_name = user_name
     @password = password
     @organization_eid = organization_eid
+    @api_key = api_key
   end
 
   def self.uhura_services
@@ -86,8 +91,8 @@ module AdRoll
   def self.included(base)
     base.class_eval do
       class << self
-        def set_account_data(user_name:, password:, organization_eid:)
-          AdRoll.set_account_data(user_name, password, organization_eid)
+        def set_account_data(user_name:, password:, organization_eid:, api_key:)
+          AdRoll.set_account_data(user_name, password, organization_eid, api_key)
         end
       end
     end

--- a/lib/adroll/api/facebook.rb
+++ b/lib/adroll/api/facebook.rb
@@ -16,7 +16,7 @@ module AdRoll
       private
 
       def service_url
-        'https://api.adroll.com/facebook'
+        'https://services.adroll.com/facebook'
       end
 
       def sanitize_params(params)

--- a/lib/adroll/client.rb
+++ b/lib/adroll/client.rb
@@ -1,12 +1,13 @@
 module AdRoll
   class Client
-    attr_accessor :user_name, :password, :organization_eid, :debug
+    attr_accessor :user_name, :password, :organization_eid, :api_key, :debug
 
-    def initialize(user_name:, password:, organization_eid:,
+    def initialize(user_name:, password:, organization_eid:, api_key:,
                    data_source: 'api', debug: false)
       @user_name = user_name
       @password = password
       @organization_eid = organization_eid
+      @api_key = api_key
       @debug = debug
       @data_source = data_source
     end

--- a/lib/adroll/service.rb
+++ b/lib/adroll/service.rb
@@ -52,9 +52,12 @@ module AdRoll
     end
 
     def make_api_call(request_method, request_uri, query_params)
+      # Include api_key with every call.
+      query_params['apikey'] = AdRoll.api_key
+
       if request_method == :get
         perform_get(request_method, request_uri, query_params)
-      elsif request_uri == 'https://api.adroll.com/v1/ad/create'
+      elsif request_uri == 'https://services.adroll.com/api/v1/ad/create'
         perform_multi_post(request_method, request_uri, query_params)
       else
         perform_post(request_method, request_uri, query_params)

--- a/spec/lib/adroll/api/ad_spec.rb
+++ b/spec/lib/adroll/api/ad_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe AdRoll::Api::Ad do
   let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
-  let!(:base_uri) { 'https://api.adroll.com/v1/ad' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/ad' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/adgroup_spec.rb
+++ b/spec/lib/adroll/api/adgroup_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe AdRoll::Api::Adgroup do
   let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
-  let!(:base_uri) { 'https://api.adroll.com/v1/adgroup' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/adgroup' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/advertisable_spec.rb
+++ b/spec/lib/adroll/api/advertisable_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Advertisable do
-  let!(:base_uri) { 'https://api.adroll.com/v1/advertisable' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/advertisable' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/campaign_spec.rb
+++ b/spec/lib/adroll/api/campaign_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Campaign do
-  let!(:base_uri) { 'https://api.adroll.com/v1/campaign' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/campaign' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/facebook_spec.rb
+++ b/spec/lib/adroll/api/facebook_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Facebook do
-  let!(:base_uri) { 'https://api.adroll.com/facebook' }
+  let!(:base_uri) { 'https://services.adroll.com/facebook' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/invoice_spec.rb
+++ b/spec/lib/adroll/api/invoice_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Invoice do
-  let!(:base_uri) { 'https://api.adroll.com/v1/invoice' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/invoice' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/organization_spec.rb
+++ b/spec/lib/adroll/api/organization_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Organization do
-  let!(:base_uri) { 'https://api.adroll.com/v1/organization' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/organization' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/pixel_spec.rb
+++ b/spec/lib/adroll/api/pixel_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Pixel do
-  let!(:base_uri) { 'https://api.adroll.com/v1/pixel' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/pixel' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/report_spec.rb
+++ b/spec/lib/adroll/api/report_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Report do
-  let!(:base_uri) { 'https://api.adroll.com/v1/report' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/report' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/rollcrawl_configuration_spec.rb
+++ b/spec/lib/adroll/api/rollcrawl_configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::RollcrawlConfiguration do
-  let!(:base_uri) { 'https://api.adroll.com/v1/rollcrawl_configuration' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/rollcrawl_configuration' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/rule_spec.rb
+++ b/spec/lib/adroll/api/rule_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Rule do
-  let!(:base_uri) { 'https://api.adroll.com/v1/rule' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/rule' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/segment_spec.rb
+++ b/spec/lib/adroll/api/segment_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::Segment do
-  let!(:base_uri) { 'https://api.adroll.com/v1/segment' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/segment' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/api/user_spec.rb
+++ b/spec/lib/adroll/api/user_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe AdRoll::Api::User do
-  let!(:base_uri) { 'https://api.adroll.com/v1/user' }
+  let!(:base_uri) { 'https://services.adroll.com/api/v1/user' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/client_spec.rb
+++ b/spec/lib/adroll/client_spec.rb
@@ -5,7 +5,8 @@ describe AdRoll::Client do
     context 'when data_source is not specified or is api' do
       client = AdRoll::Client.new user_name: 'USERNAME',
                                   password: 'PASSWORD',
-                                  organization_eid: 'ORG123XYZ'
+                                  organization_eid: 'ORG123XYZ',
+                                  api_key: 'API123XYZ'
 
       # classes = [AdRoll::Api::MobileApp]
       classes = AdRoll.api_service_classes
@@ -42,7 +43,8 @@ describe AdRoll::Client do
         {
           user_name: 'foo',
           password: 'bar',
-          organization_eid: 'spam'
+          organization_eid: 'spam',
+          api_key: 'key'
         }
       end
       before do
@@ -61,6 +63,7 @@ describe AdRoll::Client do
       client = AdRoll::Client.new user_name: 'USERNAME',
                                   password: 'PASSWORD',
                                   organization_eid: 'ORG123XYZ',
+                                  api_key: 'API123XYZ',
                                   data_source: 'uhura'
 
       # classes = [AdRoll::Uhura::Attributions]
@@ -104,7 +107,8 @@ describe AdRoll::Client do
           data_source: 'uhura',
           user_name: 'foo',
           password: 'bar',
-          organization_eid: 'spam'
+          organization_eid: 'spam',
+          api_key: 'key'
         }
       end
       before do

--- a/spec/lib/adroll/uhura/attributions_spec.rb
+++ b/spec/lib/adroll/uhura/attributions_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe AdRoll::Uhura::Attributions do
   let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
-  let!(:base_uri) { 'https://app.adroll.com/uhura/v1/attributions' }
+  let!(:base_uri) { 'https://services.adroll.com/uhura/v1/attributions' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/uhura/deliveries/domain_spec.rb
+++ b/spec/lib/adroll/uhura/deliveries/domain_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe AdRoll::Uhura::Deliveries::Domain do
   let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
-  let!(:base_uri) { 'https://app.adroll.com/uhura/v1/deliveries/domain' }
+  let!(:base_uri) { 'https://services.adroll.com/uhura/v1/deliveries/domain' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/uhura/deliveries_spec.rb
+++ b/spec/lib/adroll/uhura/deliveries_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe AdRoll::Uhura::Deliveries do
   let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
-  let!(:base_uri) { 'https://app.adroll.com/uhura/v1/deliveries' }
+  let!(:base_uri) { 'https://services.adroll.com/uhura/v1/deliveries' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/uhura/segment_deliveries_spec.rb
+++ b/spec/lib/adroll/uhura/segment_deliveries_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe AdRoll::Uhura::SegmentDeliveries do
   let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
-  let!(:base_uri) { 'https://app.adroll.com/uhura/v1/segment-deliveries' }
+  let!(:base_uri) { 'https://services.adroll.com/uhura/v1/segment-deliveries' }
 
   subject { described_class }
 

--- a/spec/lib/adroll/uhura/userlists_spec.rb
+++ b/spec/lib/adroll/uhura/userlists_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe AdRoll::Uhura::Userlists do
   let!(:basic_auth) { "#{AdRoll.user_name}:#{AdRoll.password}" }
-  let!(:base_uri) { 'https://app.adroll.com/uhura/v1/userlists' }
+  let!(:base_uri) { 'https://services.adroll.com/uhura/v1/userlists' }
 
   subject { described_class }
 

--- a/spec/lib/adroll_spec.rb
+++ b/spec/lib/adroll_spec.rb
@@ -37,6 +37,10 @@ describe AdRoll do
     it 'sets organization_eid' do
       expect(AdRoll.organization_eid).to eq('ORG123XYZ')
     end
+
+    it 'sets api_key' do
+      expect(AdRoll.api_key).to eq('API123XYZ')
+    end
   end
 
   context 'when using include' do
@@ -49,7 +53,8 @@ describe AdRoll do
     before do
       subject.set_account_data(user_name: 'username',
                                password: 'abc',
-                               organization_eid: 'abc123')
+                               organization_eid: 'abc123',
+                               api_key: 'api123')
     end
 
     it 'sets user_name' do
@@ -62,6 +67,10 @@ describe AdRoll do
 
     it 'sets organization_eid' do
       expect(AdRoll.organization_eid).to eq('abc123')
+    end
+
+    it 'sets api_key' do
+      expect(AdRoll.api_key).to eq('api123')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,14 +16,10 @@ RSpec.configure do |config|
   config.color = true
 
   config.before(:each) do
-    stub_request(:any, %r{https:\/\/api.adroll.com\/.*})
+    stub_request(:any, %r{https:\/\/services.adroll.com\/.*})
       .with(basic_auth: %w(USERNAME PASSWORD))
       .to_return(status: [200, 'OK'], body: { results: {} }.to_json)
-
-    stub_request(:any, %r{https:\/\/app.adroll.com\/.*})
-      .with(basic_auth: %w(USERNAME PASSWORD))
-      .to_return(status: [200, 'OK'], body: { results: {} }.to_json)
-    AdRoll.set_account_data('USERNAME', 'PASSWORD', 'ORG123XYZ')
+    AdRoll.set_account_data('USERNAME', 'PASSWORD', 'ORG123XYZ', 'API123XYZ')
   end
 end
 
@@ -33,3 +29,4 @@ FactoryGirl.find_definitions
 ENV['ADROLL_USERNAME'] = 'USERNAME'
 ENV['ADROLL_PASSWORD'] = 'PASSWORD'
 ENV['ADROLL_ORGANIZATION_EID'] = 'ORG123XYZ'
+ENV['ADROLL_API_KEY'] = 'API123XYZ'


### PR DESCRIPTION
Point all endpoints at services.adroll.com. Developer app apikey
is now mandatory.